### PR TITLE
Use url that shows channel content to user that don't have telegram

### DIFF
--- a/src/lib/data/contacts.ts
+++ b/src/lib/data/contacts.ts
@@ -7,7 +7,7 @@ const contacts = [
     {
         icon: "",
         name: "Canale Telegram",
-        link: "https://t.me/unixmib"
+        link: "https://t.me/s/unixmib"
     },
     {
         icon: "",

--- a/src/lib/data/events.ts
+++ b/src/lib/data/events.ts
@@ -49,7 +49,7 @@ const featuredEvents = [
         "description": "Vieni a trovarci in assemblea per discutere delle prossime iniziative e per conoscere meglio il nostro gruppo. Ti aspettiamo!",
         "cover": "",
         "date": "Tutti i mercoledì alle 10: 30",
-        "link": "https://t.me/unixmib"
+        "link": "https://t.me/s/unixmib"
     },
     {
         "title": "",


### PR DESCRIPTION
Using /s/ in the url, telegram shows a preview of the channel also to people that doesn't have a telegram account